### PR TITLE
Remove temporary workaround now that the runner fix is deployed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,10 +86,6 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATES }}
           p12-password: ${{ secrets.APPLE_CERTIFICATES_PASSWORD }}
 
-      - name: Add Python bin to PATH
-        if: matrix.name == 'ios' || matrix.name == 'macos'
-        run: echo "/Library/Frameworks/Python.framework/Versions/Current/bin" >> $GITHUB_PATH
-
       - name: Install Conan
         run: |
           pip3 install conan --pre --upgrade

--- a/recipes/android_sdl/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/recipes/android_sdl/Android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip

--- a/recipes/android_sdl/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/recipes/android_sdl/Android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip


### PR DESCRIPTION
Now that https://github.com/actions/runner-images/issues/6507 is fixed and deployed, remove manual add of python bin to PATH.